### PR TITLE
Update fof-moderator-warnings.yml

### DIFF
--- a/locale/fof-moderator-notes.yml
+++ b/locale/fof-moderator-notes.yml
@@ -19,4 +19,4 @@ fof-moderator-notes:
 
   api:
     auto-note: Bu kullanıcıya geçiş için FoF Impersonate kullandım
-    auto-note-actor: 'username' taklit etmek için FoF Impersonate kullanıldı
+    auto-note-actor: <strong>{username}</strong> taklit etmek için FoF Impersonate kullanıldı


### PR DESCRIPTION
This PR fixes the inappropriate usage of literals inside `fof-moderator-notes` that breaking the flarum. 